### PR TITLE
Resolved dependency problem in OSX

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,7 +23,7 @@ module.exports = function(grunt) {
               outDir: 'bin',
               //watch: 'test',
               options: {
-                  target: 'es5',
+                  target: 'es6',
                   module: 'commonjs',
                   sourceMap: true,
                   declaration: false,

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
     "util": "^0.10.3"
   },
   "devDependencies": {
+    "grunt": "~0.4.0",
     "grunt-cli": "~0.1.13",
     "grunt-simple-mocha": "~0.4.0",
-    "grunt-ts": "^1.11.13",
+    "grunt-ts": "^4.2.0",
     "mocha": "^1.21.4"
   },
   "scripts": {

--- a/src/Recorder.ts
+++ b/src/Recorder.ts
@@ -29,7 +29,6 @@ import Random = require('./util/Random')
 // enable proxies
 var harmonyrefl = require('harmony-reflect');
 harmonyrefl;
-declare var Proxy: <T>(target: T, handler: Object) => T;
 declare var Reflect: any
 declare var global: any
 
@@ -323,13 +322,13 @@ function proxify<T>(o: T): T {
     if (state.object2proxy.has(o)) return <T>state.object2proxy.get(o)
     if (state.proxy2object.has(o)) return o
 
-    var p = Proxy(o, Handler)
+    var p = new Proxy(o, Handler)
     state.proxy2object.set(p, o)
     state.object2proxy.set(o, p)
     return p
 }
 
-var recv = Proxy({}, {
+var recv = new Proxy({}, {
     set: function(target, name: string, value, receiver) {
         if (state != null) {
             state.addStep()
@@ -459,7 +458,7 @@ export function proxifyWithLogger<T>(o: T, tag: string = " ", level: number = 0,
             return Reflect.ownKeys(target);
         }
     }
-    var p = Proxy(o, Handler)
+    var p = new Proxy(o, Handler)
     cache.set(o, p)
     return <T>p
 }


### PR DESCRIPTION
There were two problems to install on OS X:
  1. fsevents does not work.
  2. There is no nodejs-legacy for OS X.

Thus, I changed the version of grunt-ts to install another version of fsevents and changed the target language to ES6 instead of ES5, so now mimic can be used with the newest nodejs.

Please check this pull request.