### PR TITLE
Change flag to make tests pass on Node v4

### DIFF
--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mocha --harmony --timeout 100000 bin/test/Test.js #--reporter progress
+mocha --harmony-proxies --timeout 100000 bin/test/Test.js #--reporter progress


### PR DESCRIPTION
On Mac, this flag needs to be changed to get the tests to pass on Node v4.

@stefanheule can you check if this causes problems on Ubuntu?  I don't know which Node version is being used over there.  If this change causes a problem, maybe we need to make the script a bit fancier and detect the Node version.

FWIW, the stable version of Node is now v6.  The tests don't pass there even with this change.  I'll file a separate issue for that.